### PR TITLE
Rename booster keys

### DIFF
--- a/Slugcat/modules/booster.lua
+++ b/Slugcat/modules/booster.lua
@@ -1,5 +1,5 @@
 SMODS.Booster({
-	key = "regularfoodpack",
+	key = "usefood_normal_1",
 	loc_txt = {
 		name = "Regular Food Pack",
 		text = {
@@ -29,7 +29,7 @@ SMODS.Booster({
 })
 
 SMODS.Booster({
-	key = "selectfoodpack",
+	key = "keepfood_normal_1",
 	loc_txt = {
 		name = "Select Food Pack",
 		text = {


### PR DESCRIPTION
This makes them play nice with the "established" booster pack naming scheme, with a number at the end for visual variants.
Example: Buffoon packs have two normal variants (`p_buffoon_normal_1` and `p_buffoon_normal_2`), one jumbo variant (`p_buffoon_jumbo_1`), and one mega variant (`p_buffoon_mega_1`).